### PR TITLE
Fix tag margin on multiple lines

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -250,8 +250,8 @@ a {
   }
   > header {
     padding: 24px;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: min-content min-content auto min-content;
   }
   > h2:first-child {
     margin: 0 0 0.5rem 0;
@@ -431,15 +431,13 @@ body.light {
 }
 .taglist {
   list-style: none;
-  margin: auto 0 0 0;
+  margin: -2px;
   padding: 0;
 }
 
 .taglist-item {
   display: inline-block;
-  + .taglist-item {
-    margin-left: 8px;
-  }
+  margin: 2px;
 }
 
 .taglist .tag {


### PR DESCRIPTION
Use CSS grid for the parent and negative margin on tag container (with small universal margin on actual tag).

![CleanShot 2020-10-02 at 13 15 29](https://user-images.githubusercontent.com/725067/94922226-bd80f600-04b1-11eb-8417-efefce79f6f9.png)
