### PR TITLE
Change Helmet to update title immediately

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -7,7 +7,7 @@ import { Link } from 'gatsby';
 const notFound = () => {
   return (
     <Layout>
-      <Helmet>
+      <Helmet defer={false}>
         <title>Page not found</title>
       </Helmet>
       <HeroHeader title="404: Page not found" />

--- a/src/pages/jobs.js
+++ b/src/pages/jobs.js
@@ -41,7 +41,7 @@ const Jobs = ({ data }) => {
 
   return (
     <Layout>
-      <Helmet>
+      <Helmet defer={false}>
         <title>Jobs at Close | {site.siteMetadata.title}</title>
       </Helmet>
       <HeroHeader

--- a/src/templates/blogListTemplate.js
+++ b/src/templates/blogListTemplate.js
@@ -21,7 +21,7 @@ const BlogListTemplate = ({ data, pageContext }) => {
 
   return (
     <Layout>
-      <Helmet>
+      <Helmet defer={false}>
         <title>{title}</title>
         <meta name="description" content={site.siteMetadata.description} />
       </Helmet>

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -17,7 +17,7 @@ const BlogTemplate = ({ data }) => {
 
   return (
     <Layout>
-      <Helmet>
+      <Helmet defer={false}>
         <title>
           {frontmatter.title} | {siteMetadata.title}
         </title>

--- a/src/templates/tagListTemplate.js
+++ b/src/templates/tagListTemplate.js
@@ -23,7 +23,7 @@ const TagListTemplate = ({ data, pageContext }) => {
 
   return (
     <Layout>
-      <Helmet>
+      <Helmet defer={false}>
         <title>
           {title} | {site.siteMetadata.title}
         </title>


### PR DESCRIPTION
# Why

Helmet, by default, uses `requestAnimationFrame` to trigger the updates it does. This is usually not an issue, but Chrome doesn't trigger `requestAnimationFrame` for any background tabs, causing the title to only update when you focus on the page.

Tested on other browsers (Safari/Firefox), the issue only happens on chrome

# Demo

### Before
![close blog title render - before](https://user-images.githubusercontent.com/13576166/184323305-dcc5436b-11a7-4324-83ec-05405ea26222.gif)

### After
![close blog title render - after](https://user-images.githubusercontent.com/13576166/184323332-9320234b-29f7-4a99-a91e-4cbb6d28ab3d.gif)

