### PR TITLE
Fix random zero being rendered on blog template

### DIFF
--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -27,7 +27,7 @@ const BlogTemplate = ({ data }) => {
       </Helmet>
 
       <div className={styles.container}>
-        {allLever.totalCount && (
+        {Boolean(allLever.totalCount) && (
           <Banner title="We’re hiring" url="/jobs/">
             <p>Find out about the roles currently available at Close.</p>
           </Banner>


### PR DESCRIPTION
# What

Prevent Zero from being render from a count validation

# Demo

### Before
<img width="460" alt="Screen Shot 2022-08-14 at 15 16 41" src="https://user-images.githubusercontent.com/13576166/184538859-d58889b0-2685-414d-adf4-184138dd6c3d.png">

### After
<img width="513" alt="Screen Shot 2022-08-14 at 15 16 33" src="https://user-images.githubusercontent.com/13576166/184538864-10192f9a-fe56-4ed5-8c3c-28bb15bb7b82.png">

