### PR TITLE
Add robots.txt and disallow crawling .json files

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: *.json
+
+User-agent: *
+Allow: /


### PR DESCRIPTION
After merging this, Nick (or whoever has access to Google Search Console) should [force an update](https://developers.google.com/search/docs/advanced/robots/submit-updated-robots-txt#refresh-googles-robots.txt-cache), so Google will auto-block all JSON files from now on.

Closes #91 