### PR TITLE
Tweak the first paragraph of the PG enums post.

### DIFF
--- a/_posts/2023-06-20-native-enums-or-check-constraints-in-postgresql/index.md
+++ b/_posts/2023-06-20-native-enums-or-check-constraints-in-postgresql/index.md
@@ -8,7 +8,7 @@ metaDescription: ''
 tags: [Engineering, Databases, PostgreSQL, Tips and Tricks]
 ---
 
-Recently, we had a discussion about whether we should use native enums in PostgreSQL, or rely on regular string columns with `CHECK` constraints. In the end, we decided that we wanted to go with regular string columns with `CHECK` constraints.
+Recently, we had a discussion about whether we should use native enums in PostgreSQL, or rely on regular string columns with `CHECK` constraints. In the end, we decided that we wanted to go with the latter.
 
 Tag along if you want to learn why.
 


### PR DESCRIPTION
The wording was a bit redundant there and the exact formatting / line wrapping made it look particularly jarring:

<img width="805" alt="Screenshot 2023-06-20 at 2 24 06 PM" src="https://github.com/closeio/making.close.com/assets/1718372/a8c8d707-1527-489c-8d4d-097cef5629b4">
